### PR TITLE
feat: Add setting to set style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,13 @@ repos:
       rev: v3.21.2
       hooks:
           - id: pyupgrade
-            args: ["--py39-plus"]
+            args: ["--py311-plus"]
 
     - repo: https://github.com/adamchainz/django-upgrade
       rev: "1.30.0"
       hooks:
           - id: django-upgrade
-            args: [--target-version, "4.2"]
+            args: [--target-version, "5.2"]
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.15.12

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,17 +20,10 @@ repos:
           - id: django-upgrade
             args: [--target-version, "4.2"]
 
-    - repo: https://github.com/PyCQA/flake8
-      rev: 7.3.0
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.15.12
       hooks:
-          - id: flake8
-            additional_dependencies:
-                - flake8-pyproject
-                - flake8-bugbear
-                - flake8-builtins
-                - flake8-django
-                - flake8-length
-                - flake8-logging-format
+          - id: ruff-format
 
     - repo: https://github.com/tox-dev/pyproject-fmt
       rev: v2.21.0

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,7 @@ The following additional settings can be set:
 
 * `CMS_ENABLE_UPDATE_CHECK = True` Set to False to disable the update notification.
 * `CMS_UPDATE_CHECK_TYPE = 'patch'` Set to `'patch'` to get only patch notifications. (major = x.x.x, minor = 5.x.x, patch = 5.0.x)
+* `CMS_LEGACY_STYLE` Force the legacy (django CMS 4) admin styling on or off. If unset, the legacy style is auto-detected on django CMS < 5.1 or when the project's ``base.html`` declares ``<html data-cms-theme="4">``. Set to ``True`` to force the legacy style, or ``False`` to force the new style and skip auto-detection.
 
 The update checker does not gather or record any data - however, it does query pypi.org for the latest version number.
 

--- a/djangocms_simple_admin_style/templatetags/admin_style_tags.py
+++ b/djangocms_simple_admin_style/templatetags/admin_style_tags.py
@@ -60,7 +60,7 @@ def admin_theme_class():
 def _legacy_style_active():
     """Check if a potential base template contains data-cms-theme="4" for legacy style."""
     if hasattr(settings, "CMS_LEGACY_STYLE"):
-        return settings.CMS_LEGACY_STYLE
+        return bool(settings.CMS_LEGACY_STYLE)
     try:
         from django.test import RequestFactory
         from sekizai.context_processors import sekizai

--- a/djangocms_simple_admin_style/templatetags/admin_style_tags.py
+++ b/djangocms_simple_admin_style/templatetags/admin_style_tags.py
@@ -66,7 +66,9 @@ def _legacy_style_active():
         from sekizai.context_processors import sekizai
 
         request = RequestFactory().get("/")
-        base_template = render_to_string("base.html", sekizai({"request": request}))
+        context = sekizai(request)
+        context["request"] = request
+        base_template = render_to_string("base.html", context)
         return bool(re.search(r'<html[^>]*\bdata-cms-theme=["\']4["\']', base_template))
     except (TemplateDoesNotExist, ImportError):
         pass

--- a/djangocms_simple_admin_style/templatetags/admin_style_tags.py
+++ b/djangocms_simple_admin_style/templatetags/admin_style_tags.py
@@ -59,10 +59,14 @@ def admin_theme_class():
 @cache
 def _legacy_style_active():
     """Check if a potential base template contains data-cms-theme="4" for legacy style."""
+    if hasattr(settings, "CMS_LEGACY_STYLE"):
+        return settings.CMS_LEGACY_STYLE
     try:
+        from django.test import RequestFactory
         from sekizai.context_processors import sekizai
 
-        base_template = render_to_string("base.html", sekizai())
+        request = RequestFactory().get("/")
+        base_template = render_to_string("base.html", sekizai({"request": request}))
         return bool(re.search(r'<html[^>]*\bdata-cms-theme=["\']4["\']', base_template))
     except (TemplateDoesNotExist, ImportError):
         pass


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable legacy admin style detection and update linting tooling.

New Features:
- Allow forcing legacy admin style via the `CMS_LEGACY_STYLE` setting.

Enhancements:
- Adjust legacy style detection to render the base template with a request-aware sekizai context.
- Replace flake8 with ruff-format in the pre-commit configuration.